### PR TITLE
Fix GetAssayData use for Seurat >= 5.4

### DIFF
--- a/R/migrate.R
+++ b/R/migrate.R
@@ -92,7 +92,12 @@ migrateSeuratObject <- function(
   write(toJSON(plotDataForJson), file.path(outdir, PLOT_DATA_FILE_NAME))
   message(sprintf("%s - generated", file.path(outdir, PLOT_DATA_FILE_NAME)))
 
-  counts <- GetAssayData(object, slot=slot, assay=assay)
+  if (packageVersion("Seurat") >= "5.4"){
+    counts <- GetAssayData(object, assay=assay, layer=slot)
+  } else {
+    counts <- GetAssayData(object, slot=slot, assay=assay)
+  }
+  
   expDataForJson <- writeH5ExpressionData(counts, file.path(outdir, H5_DATASET_FILE_NAME), compressionLevel=compressionLevel)
   write(toJSON(expDataForJson), file.path(outdir, EXP_DATA_FILE_NAME))
   message(sprintf("%s - generated", file.path(outdir, EXP_DATA_FILE_NAME)))


### PR DESCRIPTION
The `migrateSeuratObject` stopped working with `Seurat >= 5.4` version. Here is the error that I got:

```R
> migrateSeuratObject(pbmc, 
+                     outdir = result_folder,
+                     generateMasks = F,
+                     token = token, 
+                     name = dataset_name, # mandatory
+                     public = FALSE,
+                     curated = FALSE,
+                     species = "hs", 
+                     assay = 'RNA', 
+                     slot = 'counts',  
+                     markers = mrkrs,
+                     link = "link to original data",
+                     description = "information that helps to reproduce or find your data")
~/projects/temp/seurat-pbmc-vignette/data//pbmc_tsvAhXwd/plot_data.json - generated
Error:
! The `slot` argument of `GetAssayData()` was deprecated in SeuratObject 5.0.0 and is now
  defunct.
ℹ Please use the `layer` argument instead.
Run `rlang::last_trace()` to see where the error occurred.
```

This pull request addresses this issue
